### PR TITLE
DUWSR-34 Fix for issue where latest PR merge caused randomly generated zones to not work due to missing 'manually_chosen' variable.

### DIFF
--- a/source/dialog/startup/startup_start.sqf
+++ b/source/dialog/startup/startup_start.sqf
@@ -334,12 +334,14 @@ switch (_index) do {
 
 zones_spacing = zones_max_radius + 200;
 chosen_settings = true;  //  Give the go ! BluHQinit.sqf can continue execution
+manually_chosen = false;
 publicVariable "chosen_settings";
 publicVariable "commandpointsblu1";
 publicVariable "weather_type";
 publicVariable "blufor_ai_skill";
 publicVariable "opfor_ai_skill";
 publicVariable "enableChopperFastTravel";
+publicVariable "manually_chosen";
 
 //	commandpointsblu1 = 9999999;
 //hint format["Max radius: %1\nMin radius: %2\nZones number: %3\nCommand points: %4\nBLU AP: %5\nOPF AP: %6\nWeather type: %7\nBLU AI skill: %8\nOPF AI skill: %9",zones_max_radius,zones_min_radius,zones_number,commandpointsblu1,opfor_ap,blufor_ap,weather_type,blufor_ai_skill,opfor_ai_skill];

--- a/source/initHQ/BluHQinit.sqf
+++ b/source/initHQ/BluHQinit.sqf
@@ -89,12 +89,13 @@ if (!zones_manually_placed) then {
     // CALL ZONES GENERATION
     waitUntil {!isNil {getsize_script}};  // WAIT UNTIL THE MAPSIZE SCRIPT IS DONE
 
-    if (!zones_created && !manually_chosen) then {      // CHECK IF ZONES ARE PLACED, IF NOT EXECUTE locatorZonesV1.sqf
-        _zones_create = [50, 0.2] execVM "initZones\locatorZonesV1.sqf";   // CHECK IF ZONES HAVE ALREADY BEEN PLACED
+    // CHECK IF ZONES ARE PLACED...
+    // If not execute locatorZonesV1.sqf if the user wants them randomly placed. V2 if the user wants to place zones.
+    if (!zones_created && !manually_chosen) then {
+        _zones_create = [50, 0.2] execVM "initZones\locatorZonesV1.sqf";
     } else {
         _zones_create = [50, 0.2] execVM "initZones\locatorZonesV2.sqf";
     };
-
 };
 
 player allowDamage true;


### PR DESCRIPTION
### Issue
Fixed #34 

### Summary
When choosing the `START-R` button to randomly place enemy zones the `manually_chosen` variable was not defined. This PR defines the variable. 