### PR TITLE
Fixed UI not updating CP after recruiting operatives

### DIFF
--- a/source/dialog/operative/operative.hpp
+++ b/source/dialog/operative/operative.hpp
@@ -36,7 +36,7 @@ class operativemaingui
             y = 18.5 * GUI_GRID_H + GUI_GRID_Y;
             w = 5 * GUI_GRID_W;
             h = 1 * GUI_GRID_H;
-            action = "closeDialog 0";
+            action = "closeDialog 0; [] spawn {sleep 1;ctrlSetText [1000, format[""%1"",commandpointsblu1]]}";
         };
         class operative_recruit_button: RscButton
         {


### PR DESCRIPTION
Added a delayed (1s) update to change the CP text label to the closing 'action' of the 'Recruit Operatives' dialog EXIT button.

Fixes DUWS-R-Team/DUWS-R#6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/duws-r-team/duws-r/165)
<!-- Reviewable:end -->
