### PR TITLE
FOB & SITREP missing for players on dedicated servers

### DIFF
--- a/source/functions/initMission/fn_clientInit.sqf
+++ b/source/functions/initMission/fn_clientInit.sqf
@@ -213,7 +213,7 @@ if (isMultiplayer) then {
 
 // Generate main task
 capture_island_obj = player createSimpleTask ["taskIsland"];
-capture_island_obj setSimpleTaskDescription ["The ennemy is controlling the island, we must take it back! Capture every zone under enemy control and the mission will succeed.<br />You can let your BLUFOR forces take the island by themselves and help them getting a bigger army by accomplishing side missions. Or you can capture the zones yourself and do all the big work. As the campaign progress, the war will escalate and the armies will get stronger and start to use bigger guns.<br />To capture a zone, you need to have more units inside the zone than the enemy.<br /><br />It's up to you on how you want to play this.<br />Good luck, soldier!","Take the island",""];
+capture_island_obj setSimpleTaskDescription ["The enemy is controlling the island, we must take it back! Capture every zone under enemy control and the mission will succeed.<br />You can let your BLUFOR forces take the island by themselves and help them getting a bigger army by accomplishing side missions. Or you can capture the zones yourself and do all the big work. As the campaign progress, the war will escalate and the armies will get stronger and start to use bigger guns.<br />To capture a zone, you need to have more units inside the zone than the enemy.<br /><br />It's up to you on how you want to play this.<br />Good luck, soldier!","Take the island",""];
 
 if (mission_DUWS_firstlaunch) then {
     waitUntil {chosen_settings};
@@ -246,8 +246,10 @@ for[{_x = 2},{_x <= 20},{_x = _x + 1}] do {
     };
 };
 
-
+//adding radio mentu items
 _dynam = [player,"DynamicSupportMenu"] call BIS_fnc_addCommMenuItem;
+_dynam = [player, "SITREP"] call BIS_fnc_addCommMenuItem;
+_dynam = [player, "fob_support"] call BIS_fnc_addCommMenuItem;
 
 //Loading player position and gear.
 //TODO: Add bought supports.

--- a/source/functions/initMission/fn_clientInit.sqf
+++ b/source/functions/initMission/fn_clientInit.sqf
@@ -246,7 +246,7 @@ for[{_x = 2},{_x <= 20},{_x = _x + 1}] do {
     };
 };
 
-//adding radio mentu items
+//adding radio menu items
 _dynam = [player,"DynamicSupportMenu"] call BIS_fnc_addCommMenuItem;
 _dynam = [player, "SITREP"] call BIS_fnc_addCommMenuItem;
 _dynam = [player, "fob_support"] call BIS_fnc_addCommMenuItem;

--- a/source/includes/CfgFunctions.hpp
+++ b/source/includes/CfgFunctions.hpp
@@ -226,7 +226,7 @@ class CfgFunctions
 
         class zonescap
         {
-            class blufor_cap {}
+            class blufor_cap {};
             // [place, points, markername, markername2, triggerPos] call duws_fnc_blufor_cap
             class opfor_cap {};
             // [place, points, markername, markername2, triggerPos] call duws_fnc_opfor_cap


### PR DESCRIPTION
On dedis the SITREP and Request FOB radio functions are missing. Looks to be because BIS_fnc_addCommMenuItem is per client and not run (as far as I can see). Adding the BIS_fnc_addCommMenuItem's to the bottom of fn_clientInit.sqf works well enough for both initial and JIP players.

Tested on SP, MP and Dedicated server. No issues found as a result of this. 

Fixes #175, #135 and an unreported issue with SITREP not being available. (plus a typo and missing semicolon)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/duws-r-team/duws-r/189)
<!-- Reviewable:end -->
